### PR TITLE
Backported hierarchical and initial transition state support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,48 +1,54 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.21)
 
-project(smf VERSION 0.1.1)
+project(smf VERSION 0.1.2)
 
 # options
 # SMF config include file
 set(SMF_CONFIG_FILE "" CACHE STRING "SMF config include file")
 # Enable/disable hierarchical state machine support
 option(SMF_ANCESTOR_SUPPORT "Enable SMF hierarchical state feature" OFF)
+option(SMF_INITIAL_TRANSITION "Enable SMF initial transition feature" OFF)
+
+if (SMF_INITIAL_TRANSITION AND NOT SMF_ANCESTOR_SUPPORT)
+    message(FATAL_ERROR "SMF_INITIAL_TRANSITION cannot be enabled without SMF_ANCESTOR_SUPPORT")
+endif ()
 
 add_library(smf STATIC src/smf.c include/smf.h)
 target_include_directories(smf PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
-    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 target_compile_definitions(smf PUBLIC
-    $<$<BOOL:${SMF_CONFIG_FILE}>:SMF_CONFIG=${SMF_CONFIG_FILE}>
-    $<$<BOOL:${SMF_ANCESTOR_SUPPORT}>:CONFIG_SMF_ANCESTOR_SUPPORT>)
+        $<$<BOOL:${SMF_CONFIG_FILE}>:SMF_CONFIG=${SMF_CONFIG_FILE}>
+        $<$<BOOL:${SMF_ANCESTOR_SUPPORT}>:CONFIG_SMF_ANCESTOR_SUPPORT>
+        $<$<BOOL:${SMF_INITIAL_TRANSITION}>:CONFIG_SMF_INITIAL_TRANSITION>)
 target_compile_options(smf PRIVATE
-    $<$<OR:$<STREQUAL:$<C_COMPILER_ID>,GNU>,$<STREQUAL:$<C_COMPILER_ID>,Clang>>:-Wall -Werror -Wextra -Wpedantic -Wconversion>
-    $<$<STREQUAL:$<C_COMPILER_ID>,MSVC>:/W3 /WX>)
+        $<$<OR:$<STREQUAL:$<C_COMPILER_ID>,GNU>,$<STREQUAL:$<C_COMPILER_ID>,Clang>>:-Wall -Werror -Wextra -Wpedantic -Wconversion>
+        $<$<STREQUAL:$<C_COMPILER_ID>,MSVC>:/W3 /WX>)
 
 # Install support
 include(GNUInstallDirs)
 install(TARGETS smf
-    EXPORT smf-targets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+        EXPORT smf-targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(FILES include/smf.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(EXPORT smf-targets
-    FILE smf-targets.cmake
-    NAMESPACE ${PROJECT_NAME}::
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+        FILE smf-targets.cmake
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
 # CMake FindPackage support
 include(CMakePackageConfigHelpers)
 configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/config.cmake.in
-    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 write_basic_package_version_file(
-    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
-    VERSION "${PROJECT_VERSION}"
-    COMPATIBILITY SameMajorVersion)
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+        VERSION "${PROJECT_VERSION}"
+        COMPATIBILITY SameMajorVersion)
 install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})

--- a/include/smf.h
+++ b/include/smf.h
@@ -23,24 +23,6 @@
 #define CONFIG_SMF_INITIAL_TRANSITION 0
 #endif
 
-#define __ARG_PLACEHOLDER_1 0,
-#define __take_second_arg(__ignored, val, ...) val
-
-/*
- * Getting something that works in C and CPP for an arg that may or may
- * not be defined is tricky.  Here, if we have "#define CONFIG_BOOGER 1"
- * we match on the placeholder define, insert the "0," for arg1 and generate
- * the triplet (0, 1, 0).  Then the last step cherry-picks the 2nd arg (a one).
- * When CONFIG_BOOGER is not defined, we generate a (... 1, 0) pair, and when
- * the last step cherry-picks the 2nd arg, we get a zero.
- */
-#define __is_defined(x) ___is_defined(x)
-#define ___is_defined(val) ____is_defined(__ARG_PLACEHOLDER_##val)
-#define ____is_defined(arg1_or_junk) __take_second_arg(arg1_or_junk 1, 0, 0)
-
-#define IS_BUILTIN(option) __is_defined(option)
-#define IS_ENABLED(option) IS_BUILTIN(option)
-
 #define IF_ENABLED_IMPL_0(...)
 #define IF_ENABLED_IMPL_1(...) __VA_ARGS__
 

--- a/src/smf.c
+++ b/src/smf.c
@@ -21,17 +21,23 @@
 #define LOG_WARN(...)
 #endif /* LOG_WARN */
 
-/*
- * Private structure (to this file) used to track state machine context.
- * The structure is not used directly, but instead to cast the "internal"
- * member of the smf_ctx structure.
+#ifndef LOG_ERR
+#define LOG_ERR(...)
+#endif /* LOG_ERR */
+
+/**
+ * @brief Private structure (to this file) used to track state machine context.
+ *        The structure is not used directly, but instead to cast the "internal"
+ *        member of the smf_ctx structure.
  */
 struct internal_ctx {
     bool new_state : 1;
     bool terminate : 1;
-    bool exit : 1;
+    bool is_exit : 1;
+    bool handled : 1;
 };
 
+#ifdef CONFIG_SMF_ANCESTOR_SUPPORT
 static bool share_paren(const struct smf_state *test_state,
                         const struct smf_state *target_state)
 {
@@ -45,21 +51,12 @@ static bool share_paren(const struct smf_state *test_state,
     return false;
 }
 
-static bool last_state_share_paren(struct smf_ctx *const ctx,
-                                   const struct smf_state *state)
-{
-    /* Get parent state of previous state */
-    if (!ctx->previous) {
-        return false;
-    }
-
-    return share_paren(ctx->previous->parent, state);
-}
-
 static const struct smf_state *get_child_of(const struct smf_state *states,
                                             const struct smf_state *parent)
 {
-    for (const struct smf_state *tmp = states;; tmp = tmp->parent) {
+    const struct smf_state *tmp = states;
+
+    while (true) {
         if (tmp->parent == parent) {
             return tmp;
         }
@@ -67,6 +64,8 @@ static const struct smf_state *get_child_of(const struct smf_state *states,
         if (tmp->parent == NULL) {
             return NULL;
         }
+
+        tmp = tmp->parent;
     }
 }
 
@@ -76,28 +75,74 @@ static const struct smf_state *get_last_of(const struct smf_state *states)
 }
 
 /**
- * @brief Execute all ancestor entry actions
+ * @brief Find the Least Common Ancestor (LCA) of two states
+ *
+ * @param source transition source
+ * @param dest transition destination
+ * @return LCA state, or NULL if states have no LCA.
+ */
+static const struct smf_state *get_lca_of(const struct smf_state *source,
+                                          const struct smf_state *dest)
+{
+    for (const struct smf_state *ancestor = source->parent; ancestor != NULL;
+         ancestor = ancestor->parent) {
+        if (ancestor == dest) {
+            return ancestor->parent;
+        }
+        else if (share_paren(dest, ancestor)) {
+            return ancestor;
+        }
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Executes all entry actions from the direct child of topmost to the new
+ * state
  *
  * @param ctx State machine context
- * @param target The entry actions of this target's ancestors are executed
+ * @param new_state State we are transitioning to
+ * @param topmost State we are entering from. Its entry action is not executed
  * @return true if the state machine should terminate, else false
  */
-__unused static bool smf_execute_ancestor_entry_actions(
-    struct smf_ctx *const ctx, const struct smf_state *target)
+static bool smf_execute_all_entry_actions(struct smf_ctx *const ctx,
+                                          const struct smf_state *new_state,
+                                          const struct smf_state *topmost)
 {
     struct internal_ctx *const internal = (void *)&ctx->internal;
 
-    for (const struct smf_state *to_execute = get_last_of(target);
-         to_execute != NULL && to_execute != target;
-         to_execute = get_child_of(target, to_execute)) {
-        /* Execute parent state's entry */
-        if (!last_state_share_paren(ctx, to_execute) && to_execute->entry) {
+    if (new_state == topmost) {
+        /* There are no child states, so do nothing */
+        return false;
+    }
+
+    for (const struct smf_state *to_execute = get_child_of(new_state, topmost);
+         to_execute != NULL && to_execute != new_state;
+         to_execute = get_child_of(new_state, to_execute)) {
+        /* Keep track of the executing entry action in case it calls
+         * smf_set_state()
+         */
+        ctx->executing = to_execute;
+        /* Execute every entry action EXCEPT that of the topmost state */
+        if (to_execute->entry) {
             to_execute->entry(ctx);
 
             /* No need to continue if terminate was set */
             if (internal->terminate) {
                 return true;
             }
+        }
+    }
+
+    /* and execute the new state entry action */
+    ctx->executing = new_state;
+    if (new_state->entry) {
+        new_state->entry(ctx);
+
+        /* No need to continue if terminate was set */
+        if (internal->terminate) {
+            return true;
         }
     }
 
@@ -108,28 +153,30 @@ __unused static bool smf_execute_ancestor_entry_actions(
  * @brief Execute all ancestor run actions
  *
  * @param ctx State machine context
- * @param target The run actions of this target's ancestors are executed
  * @return true if the state machine should terminate, else false
  */
-__unused static bool smf_execute_ancestor_run_actions(struct smf_ctx *ctx)
+static bool smf_execute_ancestor_run_actions(struct smf_ctx *ctx)
 {
     struct internal_ctx *const internal = (void *)&ctx->internal;
     /* Execute all run actions in reverse order */
-
-    /* Return if the current state switched states */
-    if (internal->new_state) {
-        internal->new_state = false;
-        return false;
-    }
 
     /* Return if the current state terminated */
     if (internal->terminate) {
         return true;
     }
 
+    /* The child state either transitioned or handled it. Either way, stop
+     * propagating. */
+    if (internal->new_state || internal->handled) {
+        return false;
+    }
+
     /* Try to run parent run actions */
     for (const struct smf_state *tmp_state = ctx->current->parent;
          tmp_state != NULL; tmp_state = tmp_state->parent) {
+        /* Keep track of where we are in case an ancestor calls smf_set_state()
+         */
+        ctx->executing = tmp_state;
         /* Execute parent run action */
         if (tmp_state->run) {
             tmp_state->run(ctx);
@@ -138,127 +185,217 @@ __unused static bool smf_execute_ancestor_run_actions(struct smf_ctx *ctx)
                 return true;
             }
 
-            if (internal->new_state) {
+            /* This state dealt with it. Stop propagating. */
+            if (internal->new_state || internal->handled) {
                 break;
             }
         }
     }
 
-    internal->new_state = false;
     /* All done executing the run actions */
 
     return false;
 }
 
 /**
- * @brief Execute all ancestor exit actions
+ * @brief Executes all exit actions from ctx->current to the direct child of
+ * topmost
  *
  * @param ctx State machine context
- * @param target The exit actions of this target's ancestors are executed
+ * @param topmost State we are exiting to. Its exit action is not executed
  * @return true if the state machine should terminate, else false
  */
-__unused static bool smf_execute_ancestor_exit_actions(
-    struct smf_ctx *const ctx, const struct smf_state *target)
+static bool smf_execute_all_exit_actions(struct smf_ctx *const ctx,
+                                         const struct smf_state *topmost)
 {
     struct internal_ctx *const internal = (void *)&ctx->internal;
 
-    /* Execute all parent exit actions in reverse order */
+    for (const struct smf_state *to_execute = ctx->current;
+         to_execute != NULL && to_execute != topmost;
+         to_execute = to_execute->parent) {
+        if (to_execute->exit) {
+            to_execute->exit(ctx);
 
-    for (const struct smf_state *tmp_state = ctx->current->parent;
-         tmp_state != NULL; tmp_state = tmp_state->parent) {
-        if (!share_paren(target->parent, tmp_state) && tmp_state->exit) {
-            tmp_state->exit(ctx);
-
-            /* No need to continue if terminate was set */
+            /* No need to continue if terminate was set in the exit action */
             if (internal->terminate) {
                 return true;
             }
         }
     }
+
     return false;
+}
+#endif /* CONFIG_SMF_ANCESTOR_SUPPORT */
+
+/**
+ * @brief Reset the internal state of the state machine back to default values.
+ * Should be called on entry to smf_set_initial() and smf_set_state().
+ *
+ * @param ctx State machine context.
+ */
+static void smf_clear_internal_state(struct smf_ctx *ctx)
+{
+    struct internal_ctx *const internal = (void *)&ctx->internal;
+
+    internal->is_exit = false;
+    internal->terminate = false;
+    internal->handled = false;
+    internal->new_state = false;
 }
 
 void smf_set_initial(struct smf_ctx *ctx, const struct smf_state *init_state)
 {
-    struct internal_ctx *const internal = (void *)&ctx->internal;
+#ifdef CONFIG_SMF_INITIAL_TRANSITION
+    /*
+     * The final target will be the deepest leaf state that
+     * the target contains. Set that as the real target.
+     */
+    while (init_state->initial) {
+        init_state = init_state->initial;
+    }
+#endif
 
-    internal->exit = false;
-    internal->terminate = false;
+    smf_clear_internal_state(ctx);
     ctx->current = init_state;
     ctx->previous = NULL;
     ctx->terminate_val = 0;
 
-    if (IS_ENABLED(CONFIG_SMF_ANCESTOR_SUPPORT)) {
-        internal->new_state = false;
+#ifdef CONFIG_SMF_ANCESTOR_SUPPORT
+    struct internal_ctx *const internal = (void *)&ctx->internal;
 
-        if (smf_execute_ancestor_entry_actions(ctx, init_state)) {
+    ctx->executing = init_state;
+    const struct smf_state *topmost = get_last_of(init_state);
+
+    /* Execute topmost state entry action, since
+     * smf_execute_all_entry_actions() doesn't
+     */
+    if (topmost->entry) {
+        topmost->entry(ctx);
+        if (internal->terminate) {
+            /* No need to continue if terminate was set */
             return;
         }
     }
 
-    /* Now execute the initial state's entry action */
+    if (smf_execute_all_entry_actions(ctx, init_state, topmost)) {
+        /* No need to continue if terminate was set */
+        return;
+    }
+#else
+    /* execute entry action if it exists */
     if (init_state->entry) {
         init_state->entry(ctx);
     }
+#endif
 }
 
-void smf_set_state(struct smf_ctx *const ctx, const struct smf_state *target)
+void smf_set_state(struct smf_ctx *const ctx, const struct smf_state *new_state)
 {
     struct internal_ctx *const internal = (void *)&ctx->internal;
 
-    /*
-     * It does not make sense to call set_state in an exit phase of a state
-     * since we are already in a transition; we would always ignore the
-     * intended state to transition into.
-     */
-    if (internal->exit) {
-        LOG_WARN("Calling %s from exit action", __func__);
+    if (new_state == NULL) {
+        LOG_ERR("new_state cannot be NULL");
         return;
     }
 
-    internal->exit = true;
+    /*
+     * It does not make sense to call smf_set_state in an exit phase of a
+     * state since we are already in a transition; we would always ignore
+     * the intended state to transition into.
+     */
+    if (internal->is_exit) {
+        LOG_ERR("Calling %s from exit action", __func__);
+        return;
+    }
 
-    /* Execute the current states exit action */
-    if (ctx->current->exit) {
-        ctx->current->exit(ctx);
+#ifdef CONFIG_SMF_ANCESTOR_SUPPORT
+    const struct smf_state *topmost;
 
-        /*
-         * No need to continue if terminate was set in the
-         * exit action
-         */
+    if (share_paren(ctx->executing, new_state)) {
+        /* new state is a parent of where we are now*/
+        topmost = new_state;
+    }
+    else if (share_paren(new_state, ctx->executing)) {
+        /* we are a parent of the new state */
+        topmost = ctx->executing;
+    }
+    else {
+        /* not directly related, find LCA */
+        topmost = get_lca_of(ctx->executing, new_state);
+    }
+
+    internal->is_exit = true;
+    internal->new_state = true;
+
+    /* call all exit actions up to (but not including) the topmost */
+    if (smf_execute_all_exit_actions(ctx, topmost)) {
+        /* No need to continue if terminate was set in the exit action */
+        return;
+    }
+
+    /* if self-transition, call the exit action */
+    if ((ctx->executing == new_state) && (new_state->exit)) {
+        new_state->exit(ctx);
+
+        /* No need to continue if terminate was set in the exit action */
         if (internal->terminate) {
             return;
         }
     }
 
-    if (IS_ENABLED(CONFIG_SMF_ANCESTOR_SUPPORT)) {
-        internal->new_state = true;
+    internal->is_exit = false;
 
-        if (smf_execute_ancestor_exit_actions(ctx, target)) {
+    /* if self transition, call the entry action */
+    if ((ctx->executing == new_state) && (new_state->entry)) {
+        new_state->entry(ctx);
+
+        /* No need to continue if terminate was set in the entry action */
+        if (internal->terminate) {
             return;
         }
     }
-
-    internal->exit = false;
+#ifdef CONFIG_SMF_INITIAL_TRANSITION
+    /*
+     * The final target will be the deepest leaf state that
+     * the target contains. Set that as the real target.
+     */
+    while (new_state->initial) {
+        new_state = new_state->initial;
+    }
+#endif
 
     /* update the state variables */
     ctx->previous = ctx->current;
-    ctx->current = target;
+    ctx->current = new_state;
 
-    if (IS_ENABLED(CONFIG_SMF_ANCESTOR_SUPPORT)) {
-        if (smf_execute_ancestor_entry_actions(ctx, target)) {
+    /* call all entry actions (except those of topmost) */
+    if (smf_execute_all_entry_actions(ctx, new_state, topmost)) {
+        /* No need to continue if terminate was set in the entry action */
+        return;
+    }
+#else
+    /* Flat state machines have a very simple transition: */
+    if (ctx->current->exit) {
+        internal->is_exit = true;
+        ctx->current->exit(ctx);
+        /* No need to continue if terminate was set in the exit action */
+        if (internal->terminate) {
+            return;
+        }
+        internal->is_exit = false;
+    }
+    /* update the state variables */
+    ctx->previous = ctx->current;
+    ctx->current = new_state;
+
+    if (ctx->current->entry) {
+        ctx->current->entry(ctx);
+        /* No need to continue if terminate was set in the entry action */
+        if (internal->terminate) {
             return;
         }
     }
-
-    /* Now execute the target entry action */
-    if (ctx->current->entry) {
-        ctx->current->entry(ctx);
-        /*
-         * If terminate was set, it will be handled in the
-         * smf_run_state function
-         */
-    }
+#endif
 }
 
 void smf_set_terminate(struct smf_ctx *ctx, int32_t val)
@@ -267,6 +404,13 @@ void smf_set_terminate(struct smf_ctx *ctx, int32_t val)
 
     internal->terminate = true;
     ctx->terminate_val = val;
+}
+
+void smf_set_handled(struct smf_ctx *ctx)
+{
+    struct internal_ctx *const internal = (void *)&ctx->internal;
+
+    internal->handled = true;
 }
 
 int32_t smf_run_state(struct smf_ctx *const ctx)
@@ -278,15 +422,24 @@ int32_t smf_run_state(struct smf_ctx *const ctx)
         return ctx->terminate_val;
     }
 
+    /* Executing a states run function could cause a transition, so clear
+     * the internal state to ensure that the transition is handled
+     * correctly.
+     */
+    smf_clear_internal_state(ctx);
+#ifdef CONFIG_SMF_ANCESTOR_SUPPORT
+    ctx->executing = ctx->current;
+#endif
+
     if (ctx->current->run) {
         ctx->current->run(ctx);
     }
 
-    if (IS_ENABLED(CONFIG_SMF_ANCESTOR_SUPPORT)) {
-        if (smf_execute_ancestor_run_actions(ctx)) {
-            return ctx->terminate_val;
-        }
+#ifdef CONFIG_SMF_ANCESTOR_SUPPORT
+    if (smf_execute_ancestor_run_actions(ctx)) {
+        return ctx->terminate_val;
     }
+#endif
 
     return 0;
 }


### PR DESCRIPTION
Introduced CONFIG_SMF_ANCESTOR_SUPPORT for hierarchical state machines and CONFIG_SMF_INITIAL_TRANSITION for initial state transitions. Updated `SMF_CREATE_STATE` macro and related functions to support these features. Adjusted the build system to ensure proper configuration and validation of newly added options.